### PR TITLE
Establish Sanity backend support resources

### DIFF
--- a/components/Support/Resources.js
+++ b/components/Support/Resources.js
@@ -37,5 +37,3 @@ export const Resources = ({ resourcesList }) => {
     </div>
   );
 };
-
-// Hello World

--- a/components/Support/Resources.js
+++ b/components/Support/Resources.js
@@ -37,3 +37,5 @@ export const Resources = ({ resourcesList }) => {
     </div>
   );
 };
+
+// Hello World

--- a/components/Support/Resources.js
+++ b/components/Support/Resources.js
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import styles from "../../styles/Support/Resources.module.scss";
+import { urlFor } from "../../lib/sanity";
 
 export const Resources = ({ resourcesList }) => {
   return (
@@ -11,7 +12,7 @@ export const Resources = ({ resourcesList }) => {
               <div className={styles["resource-card"]} key={resource.id}>
                 <div onClick={() => window.open(resource.url, "_blank")}>
                   <Image
-                    src={resource.image}
+                    src={urlFor(resource.image).url()}
                     alt={`Image of ${resource.title}`}
                     loading="lazy"
                     width={200}
@@ -19,7 +20,7 @@ export const Resources = ({ resourcesList }) => {
                     layout="responsive"
                   />
                   <h3>{resource.title}</h3>
-                  <p className={styles.description}>{resource.content}</p>
+                  <p className={styles.description}>{resource.description}</p>
                   <div className={styles["categories"]}>
                     <p>{resource.category[0]}</p>
                     &nbsp;&nbsp;&nbsp;&nbsp;

--- a/components/Support/ReusableButtons.js
+++ b/components/Support/ReusableButtons.js
@@ -21,11 +21,12 @@ export const ReusableButtons = ({buttonData, group, changeSelection}) => {
     }
 
     const allButtonTexts = [...getButtonTexts(buttonData)];
+    const alphabeticalButtons = allButtonTexts.sort((a, b) => a.localeCompare(b))
     
     return (
         <div>
             {
-                allButtonTexts.map((text, i)=>{
+                alphabeticalButtons.map((text, i)=>{
                     return <button className={styles.button} type="button" onClick={()=> changeSelection(text)} key={i}>{text}</button>
                 })
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "start-asian-love",
       "version": "0.1.0",
       "dependencies": {
         "@svgr/webpack": "^5.5.0",

--- a/pages/support.js
+++ b/pages/support.js
@@ -6,9 +6,19 @@ import { Footer } from "../components/Layout/Footer";
 import { ReusableButtons } from "../components/Support/ReusableButtons";
 import ScrollButton from "../components/Layout/ScrollButton";
 import { Resources } from "../components/Support/Resources";
-import resourcesData from "../database/SupportResources";
+import { sanityClient } from "../lib/sanity";
 
-export default function Support() {
+const supportQuery = `*[_type == "support"]{
+  _id, 
+  title, 
+  url, 
+  allyship, 
+  category, 
+  description, 
+  image
+  }`;
+
+export default function Support({ resourcesData }) {
   const [allyship, setAllyship] = useState("all");
   const [category, setCategory] = useState("All");
 
@@ -24,6 +34,7 @@ export default function Support() {
   // the default being anyone && all
   // otherwise, since the resources first depend on the allyship, filter the resources by allyship then by category (unless allyship is anyone)
   // future: if a resource has more than 2 categories?
+
   const filterResources = () => {
     if (allyship === "all" && category === "All") {
       return resourcesData;
@@ -190,4 +201,11 @@ export default function Support() {
       <Footer />
     </div>
   );
+}
+
+export async function getStaticProps() {
+  const resourcesData = await sanityClient.fetch(supportQuery);
+  return {
+    props: { resourcesData },
+  };
 }

--- a/pages/support.js
+++ b/pages/support.js
@@ -18,7 +18,7 @@ const supportQuery = `*[_type == "support"]{
   image
   }`;
 
-export default function Support({ resourcesData }) {
+export default function Support({ resources }) {
   const [allyship, setAllyship] = useState("all");
   const [category, setCategory] = useState("All");
 
@@ -37,21 +37,21 @@ export default function Support({ resourcesData }) {
 
   const filterResources = () => {
     if (allyship === "all" && category === "All") {
-      return resourcesData;
+      return resources;
     } else if (allyship === "all" && category !== "All") {
-      let filteredResourcesByCategory = resourcesData.filter((resource) => {
+      let filteredResourcesByCategory = resources.filter((resource) => {
         return resource.category[0] === category || resource.category[1] === category;
       });
 
       return filteredResourcesByCategory;
     } else if (allyship === "asian" && category === "All") {
-      let filteredResourcesByAllyship = resourcesData.filter((resource) => {
+      let filteredResourcesByAllyship = resources.filter((resource) => {
         return resource.allyship[0] === "asian" || resource.allyship[1] === "asian";
       });
 
       return filteredResourcesByAllyship;
     } else if (allyship === "asian" && category !== "All") {
-      let filteredResourcesByAllyship = resourcesData.filter((resource) => {
+      let filteredResourcesByAllyship = resources.filter((resource) => {
         return resource.allyship[0] === "asian" || resource.allyship[1] === "asian";
       });
 
@@ -61,13 +61,13 @@ export default function Support({ resourcesData }) {
 
       return filteredResourcesByCategory;
     } else if (allyship === "bipoc" && category === "All") {
-      let filteredResourcesByAllyship = resourcesData.filter((resource) => {
+      let filteredResourcesByAllyship = resources.filter((resource) => {
         return resource.allyship[0] === "bipoc" || resource.allyship[1] === "bipoc";
       });
 
       return filteredResourcesByAllyship;
     } else if (allyship === "bipoc" && category !== "All") {
-      let filteredResourcesByAllyship = resourcesData.filter((resource) => {
+      let filteredResourcesByAllyship = resources.filter((resource) => {
         return resource.allyship[0] === "bipoc" || resource.allyship[1] === "bipoc";
       });
 
@@ -76,13 +76,13 @@ export default function Support({ resourcesData }) {
       });
       return filteredResourcesByCategory;
     } else if (allyship === "white" && category === "All") {
-      let filteredResourcesByAllyship = resourcesData.filter((resource) => {
+      let filteredResourcesByAllyship = resources.filter((resource) => {
         return resource.allyship[0] === "white" || resource.allyship[1] === "white";
       });
 
       return filteredResourcesByAllyship;
     } else if (allyship === "white" && category !== "All") {
-      let filteredResourcesByAllyship = resourcesData.filter((resource) => {
+      let filteredResourcesByAllyship = resources.filter((resource) => {
         return resource.allyship[0] === "white" || resource.allyship[1] === "white";
       });
 
@@ -171,13 +171,13 @@ export default function Support({ resourcesData }) {
       <div className={styles["filter-section"]}>
         <h3>Who are these resources for?</h3>
         <ReusableButtons
-          buttonData={resourcesData}
+          buttonData={resources}
           group={"allyships"}
           changeSelection={changeAllyship}
         />
         <h3>Filter by Category</h3>
         <ReusableButtons
-          buttonData={resourcesData}
+          buttonData={resources}
           group={"categories"}
           changeSelection={changeCategory}
         />
@@ -204,8 +204,8 @@ export default function Support({ resourcesData }) {
 }
 
 export async function getStaticProps() {
-  const resourcesData = await sanityClient.fetch(supportQuery);
+  const resources = await sanityClient.fetch(supportQuery);
   return {
-    props: { resourcesData },
+    props: { resources },
   };
 }


### PR DESCRIPTION
## Description

Related Issue: #37 

<!-- Include what you changed, why you chose this approach -->

- We successfully fetched and rendered support resources from the Sanity backend.

- The pages/support.js file includes the following to fetch the support database from Sanity:
    - **sanityClient** import
    - **GROQ query** for support resources
    - **getStaticProps** for resourcesData

- After initial undefined errors, Daniel determined the solution for returning "resourcesData" as props that the filterResources function requires.

- The **urlFor hook** is being imported in components/Support/Resources.js.

- **Some Issues to Note:** 
    - The allyship buttons are in a slightly different order, with "white" now first. 
        - **Edited to Add**: Allyship buttons are now in alphabetical order.
    - The resource cards are now in a different order. 
    - Despite the rearrangement, the filtering and links still work properly.

Resources:

<!-- Resources or packages (if any) you used -->

- [Next.js for Beginners](https://youtu.be/1WmNXEVia8I) YouTube video.

- [Next-Sanity Toolkit](https://github.com/sanity-io/next-sanity)

- [GROQ Query Cheat Sheet](https://www.sanity.io/docs/query-cheat-sheet)

- [Sanity Documentation](https://github.com/sanity-io/next-sanity)

## Acceptance Criteria

<!-- Include the AC from the GitHub issue -->

- [x]  Fetch and render support resources database from Sanity. 

## Self-check

Please check all that apply:

<!-- Put an `x` for the applicable box: -->

- [x] I have reviewed my code, refactored it to the best of my abilities and deleted all unnecessary code
- [x] I have commented my code, particularly in hard-to-understand areas; my comments are concise
- [x] I have made corresponding changes to the documentation

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓ | :sparkles: New feature     |
| ✓ | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, provide screenshots or gifs -->
**Note the initial order of allyship buttons and cards.**
<img width="1648" alt="Screen Shot 2021-08-11 at 4 31 55 PM" src="https://user-images.githubusercontent.com/61435324/129104678-3e6bc73e-0d4f-4342-9305-ced36cda4df7.png">

<img width="1654" alt="Screen Shot 2021-08-11 at 4 32 39 PM" src="https://user-images.githubusercontent.com/61435324/129104712-f74dc015-b2fd-4729-80d9-17fe7db1f72b.png">

### After

<!-- If UI feature, provide screenshots or gifs -->
**Note the rearranged order of allyship buttons and cards.**
<img width="1668" alt="Screen Shot 2021-08-11 at 4 36 59 PM" src="https://user-images.githubusercontent.com/61435324/129104826-28232696-f907-4aab-9bf8-0194c2416686.png">

<img width="1654" alt="Screen Shot 2021-08-11 at 4 37 14 PM" src="https://user-images.githubusercontent.com/61435324/129104833-634c7ccf-2487-40d8-ac3f-bc58256c7b07.png">


## Testing Steps / QA Criteria

<!-- Provide steps those who are testing need to follow to properly test your additions. -->

- Switch to branch: `git checkout sanity-backend-support`
- Install dependencies: `npm install`
- Run the server: `npm run dev`
- In the Support page, click allyship and category buttons to filter. Click cards, check for any typos, and check links.
